### PR TITLE
🔧 Add renovate base config version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Friedinger/Configs//renovate/recommended.json"]
+  "extends": ["github>Friedinger/Configs//renovate/recommended.json#1.1.0"]
 }


### PR DESCRIPTION
This pull request makes a minor update to the Renovate configuration by pinning the base configuration to a specific version for improved stability and predictability.

* Pin the `extends` field in `.github/renovate.json` to use version `1.1.0` of the shared configuration, instead of the latest version.