### PR TITLE
🔧 Fix versioning format in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Friedinger/Configs//renovate/recommended.json#1.1.0"]
+  "extends": ["github>Friedinger/Configs//renovate/recommended.json#v1.1.0"]
 }


### PR DESCRIPTION
This pull request makes a minor update to the `.github/renovate.json` configuration file, correcting the version reference format for the extended configuration.