### PR TITLE
🔧 Update Renovate configuration to use new user specific config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Friedinger/Configs//renovate/recommended.json#v1.1.0"]
+  "extends": [
+    "github>Friedinger/configs//renovate/recommended.json#v1.2.0",
+    "github>Friedinger/configs//renovate/friedinger.json#v1.2.0"
+  ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to use newer and more comprehensive shared presets. The configuration now extends from two updated preset files, which should provide improved and more consistent dependency management settings.

**Renovate configuration updates:**

* Updated the `extends` field in `.github/renovate.json` to use the latest version (`v1.2.0`) of the recommended preset and added an additional shared preset for more comprehensive configuration.