### PR TITLE
👷 Add conventions workflow

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -1,0 +1,11 @@
+name: Enforce conventions
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  run:
+    uses: Friedinger/configs/.github/workflows/action-conventions.yml@v1.2.0
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to enforce repository conventions whenever a pull request is opened.

Workflow automation:

* Added a new workflow file `.github/workflows/conventions.yml` that triggers on pull request openings and uses a shared workflow (`action-conventions.yml`) to enforce conventions.